### PR TITLE
fixed hover-state overflow issue

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -87,3 +87,16 @@
   width: 0;
   height: 0;
 }
+
+
+/* 
+speaker hover-state max widths
+as width of images is 300x300px
+*/
+.speaker .social-links {
+  max-width: 300px;
+}
+
+.speaker .hover-state {
+  max-width: 300px;
+}


### PR DESCRIPTION
As the speaker container's size is decided by Bootstrap so sometimes image size (which is fixed at 300) can be smaller than container size. In such a case,hover _film_ will overflow. Also social-links will be misaligned. 
## Before

![before](https://cloud.githubusercontent.com/assets/4047597/13521923/3d851c40-e212-11e5-8c2f-1fa50d0ddf1f.png)
## After

![after](https://cloud.githubusercontent.com/assets/4047597/13521943/5fbdb1b4-e212-11e5-8907-1f3fed5c691d.png)
