### PR TITLE
proper motion of slider

### DIFF
--- a/css/theme-lava.css
+++ b/css/theme-lava.css
@@ -653,11 +653,6 @@ nav .container {
   -webkit-transform: translate3d(0px, 0px, 0px);
   -moz-transform: translate3d(0px, 0px, 0px);
 }
-.reveal-sidebar {
-  transform: translate3d(-300px, 0px, 0px);
-  -webkit-transform: translate3d(-300px, 0px, 0px);
-  -moz-transform: translate3d(-300px, 0px, 0px);
-}
 .sidebar-content {
   padding: 0px 24px;
   margin-top: 24px;


### PR DESCRIPTION
Initially the slider while moving makes the rest of the page to shift left which is not a good in user experience perspective.

slider should be like get into the page without disturbing the current page.
@sudheesh001 @championswimmer @jig08 
have a look on [preview](http://silentflame.github.io/2016.fossasia.org/) for the smooth slider action.
