### PR TITLE
Fixed speaker images scaling issue

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -115,6 +115,5 @@ as width of images is 300x300px
 }
 
 .background-image {
-  height: 300px;
   width: 300px;
 }


### PR DESCRIPTION
The addition of "height: 300px;" property in the .background-image class was the cause of the issue. Removing it solves the scaling issue of the images.

Before the change

![imageedit_1_2200141627](https://cloud.githubusercontent.com/assets/14184381/18707749/0d54f3d2-8015-11e6-8fbd-c14fd8d5eb1a.png)

After the change

![imageedit_2_6961281843](https://cloud.githubusercontent.com/assets/14184381/18707665/cadf2202-8014-11e6-892a-8e6fe6a3b1e2.png)
